### PR TITLE
fix: Transfer Entity, Repository, Service, and Test Integration (#12)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
- "java.configuration.updateBuildConfiguration": "automatic"
+ "java.configuration.updateBuildConfiguration": "automatic",
+ "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/backend/src/test/java/com/fintransfer/repository/TransferRepositoryTest.java
+++ b/backend/src/test/java/com/fintransfer/repository/TransferRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.fintransfer.repository;
+
+import com.fintransfer.model.Transfer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class TransferRepositoryTest {
+
+    @Autowired
+    private TransferRepository repository;
+
+    @Test
+    void shouldSaveAndFindTransfer() {
+        Transfer transfer = Transfer.builder()
+                .sourceAccount("1111111111")
+                .destinationAccount("2222222222")
+                .amount(new BigDecimal("500.00"))
+                .fee(new BigDecimal("5.00"))
+                .scheduledDate(LocalDate.now().plusDays(2))
+                .build();
+
+        Transfer saved = repository.save(transfer);
+        assertThat(saved.getId()).isNotNull();
+
+        Transfer found = repository.findById(saved.getId()).orElse(null);
+        assertThat(found).isNotNull();
+        assertThat(found.getAmount()).isEqualByComparingTo("500.00");
+        assertThat(found.getSourceAccount()).isEqualTo("1111111111");
+        assertThat(found.getDestinationAccount()).isEqualTo("2222222222");
+    }
+}

--- a/backend/src/test/java/com/fintransfer/service/TransferServiceTest.java
+++ b/backend/src/test/java/com/fintransfer/service/TransferServiceTest.java
@@ -1,0 +1,35 @@
+package com.fintransfer.service;
+
+import com.fintransfer.model.Transfer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TransferServiceTest {
+
+    @Autowired
+    private TransferService service;
+
+    @Test
+    void shouldSaveAndRetrieveTransfer() {
+        Transfer transfer = Transfer.builder()
+                .sourceAccount("1234567890")
+                .destinationAccount("0987654321")
+                .amount(new BigDecimal("1000.00"))
+                .fee(new BigDecimal("0.00"))
+                .scheduledDate(LocalDate.now().plusDays(1))
+                .build();
+
+        Transfer saved = service.save(transfer);
+        assertThat(saved.getId()).isNotNull();
+
+        Transfer retrieved = service.findById(saved.getId()).orElseThrow();
+        assertThat(retrieved.getAmount()).isEqualByComparingTo("1000.00");
+    }
+}


### PR DESCRIPTION
- Correct package declarations for all Java files
- Fix JPA imports and Lombok usage in Transfer.java
- Ensure TransferRepository extends JpaRepository<Transfer, Long>
- Move TransferServiceTest to src/test/java
- Create TransferRepositoryTest in src/test/java/com/fintransfer/repository/
- Remove unnecessary test imports
- Validate Maven build and test execution
- Ensure H2 and JPA configuration in application.properties

Closes #12